### PR TITLE
feat(android): change getDocuments return value

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.0.0
+version: 2.0.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-firestore

--- a/android/src/firebase/firestore/TitaniumFirebaseFirestoreModule.kt
+++ b/android/src/firebase/firestore/TitaniumFirebaseFirestoreModule.kt
@@ -11,10 +11,11 @@ package firebase.firestore
 
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
-import org.appcelerator.kroll.KrollModule
 import org.appcelerator.kroll.KrollDict
 import org.appcelerator.kroll.KrollFunction
+import org.appcelerator.kroll.KrollModule
 import org.appcelerator.kroll.annotations.Kroll
+
 
 @Kroll.module(name = "TitaniumFirebaseFirestore", id = "firebase.firestore")
 class TitaniumFirebaseFirestoreModule: KrollModule() {
@@ -53,10 +54,17 @@ class TitaniumFirebaseFirestoreModule: KrollModule() {
 		Firebase.firestore.collection(collection)
 			.get()
 			.addOnSuccessListener { it ->
-				val documents: List<Map<String, Any>?> = it.documents.map { snapshot -> snapshot.data }
+
+				val list = mutableListOf<Map<String, Any>>()
+				for (document in it.documents) {
+					val map = mutableMapOf<String, Any>()
+					map["id"] = document.id
+					map["data"] = KrollDict(document.data)
+					list.add(map)
+				}
 				val event = KrollDict()
 				event["success"] = true
-				event["documents"] = documents.toTypedArray()
+				event["documents"] = list.toTypedArray()
 
 				callback.callAsync(getKrollObject(), event)
 			}

--- a/android/src/firebase/firestore/TitaniumFirebaseFirestoreModule.kt
+++ b/android/src/firebase/firestore/TitaniumFirebaseFirestoreModule.kt
@@ -57,11 +57,11 @@ class TitaniumFirebaseFirestoreModule: KrollModule() {
 
 				val list = mutableListOf<Map<String, Any>>()
 				for (document in it.documents) {
-					val map = mutableMapOf<String, Any>()
-					map["id"] = document.id
-					map["data"] = KrollDict(document.data)
-					list.add(map)
+					val d = KrollDict(document.data)
+					d["_id"] = document.id
+					list.add(d)
 				}
+
 				val event = KrollDict()
 				event["success"] = true
 				event["documents"] = list.toTypedArray()


### PR DESCRIPTION
The current `getDocuments` call will just return a list of the data values but not the ID of the actual document.
```js
[
{  image: '',    name: 'Name1'  },
{  name: 'Nam2'  },
{  name: 'Name3'  }
]
```

This PR adds the ID as `_id`: 
```js
 [
  { name: 'Name1', image: '', _id: '8zNNaaaCXyeHY5ETaaa' },
  { name: 'Name2', _id: 'NR6NSOOYaaaH4aaaaL' },
  { name: 'Name3', _id: 'SbQoWJ4h8aaauM1aaadS' }
 ]
```

I've used `_id` so it won't clash if you defined an `id` node yourself. I have a previous commit where I've change the structure to `id: "...", data: {}` but that would break existing apps.

[firebase.firestore-android-2.0.0.zip](https://github.com/hansemannn/titanium-firebase-firestore/files/12259191/firebase.firestore-android-2.0.0.zip)

